### PR TITLE
fix: prevent widget decoration beyond document end for vim keybindings

### DIFF
--- a/src/copy-inline-code-view-plugin.ts
+++ b/src/copy-inline-code-view-plugin.ts
@@ -57,7 +57,7 @@ class CopyInlineCodeViewPlugin implements PluginValue {
 							node.from,
 							node.to
 						);
-						if (shouldExclude(codeText, filters)) {
+						if (shouldExclude(codeText, filters) || node.to + 1 > view.state.doc.length) {
 							return;
 						}
 						builder.add(


### PR DESCRIPTION
This is a fix for #21 