### PR TITLE
Remove gap between words when invisible

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -13,16 +13,16 @@
 
 .show-on-hover {
 	cursor: pointer;
-	opacity: 0;
+	display: none;
 }
 
 /* Source Mode */
 .cm-line:hover .show-on-hover {
-	opacity: 1;
+	display: inline;
 }
 /* Reading Mode */
 code:hover .show-on-hover {
-	opacity: 1;
+	display: inline;
 }
 
 .tasks-setting-important {


### PR DESCRIPTION
Currently it leaves an awkward gap when not hovered over:

<img width="283" height="53" alt="image" src="https://github.com/user-attachments/assets/ce4b85f8-ec40-42b7-b859-0b3dd62ec90e" />


Hovering:

<img width="265" height="55" alt="image" src="https://github.com/user-attachments/assets/b18304d2-85de-47e6-96c8-e8d670bfd5e6" />

---

After this change, it collapses when not used:

<img width="249" height="58" alt="image" src="https://github.com/user-attachments/assets/c7a3771e-5576-45ed-8819-7041ece9724e" />

And looks the same when hovered:

<img width="260" height="54" alt="image" src="https://github.com/user-attachments/assets/c937bce3-01fb-4b53-8da0-76afdccbb285" />



The layout shift when hovering is not nearly annoying as gaps that are always present. 

